### PR TITLE
bit_size-count-function-added

### DIFF
--- a/src/gadget_bound_check.rs
+++ b/src/gadget_bound_check.rs
@@ -10,6 +10,7 @@ use curve25519_dalek::ristretto::CompressedRistretto;
 use bulletproofs::r1cs::LinearCombination;
 use merlin::Transcript;
 use rand::{RngCore, CryptoRng};
+use std::cmp;
 
 use crate::r1cs_utils::{AllocatedQuantity, positive_no_gadget, constrain_lc_with_scalar};
 
@@ -114,6 +115,11 @@ pub fn verify_proof_of_bounded_num(lower: u64, upper: u64, max_bits_in_val: usiz
     verifier.verify(&proof, &pc_gens, &bp_gens)
 }
 
+fn count_log_bits(number: u64) -> usize {
+    let logaritm_int = cmp::min((number as f64).log2() as usize + 1, 64 as usize);
+    return logaritm_int as usize
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,8 +147,8 @@ mod tests {
         let min = 10;
         let max = 100;
 
-        // Since max fits in 7 bits
-        let bit_size = 7;
+        let bit_size = count_log_bits(max);
+        println!("bit_size is {}", &bit_size);
 
         bound_check(min, max, bit_size)
     }
@@ -152,8 +158,8 @@ mod tests {
         let min = std::u64::MAX/100001;
         let max = std::u64::MAX/100000;
 
-        // Since max fits in 47 bits
-        let bit_size = 47;
+        let bit_size = count_log_bits(max);
+        println!("bit_size is {}", &bit_size);
 
         bound_check(min, max, bit_size);
 
@@ -162,4 +168,5 @@ mod tests {
 
         bound_check(min, max, bit_size);
     }
+
 }

--- a/src/gadget_range_proof.rs
+++ b/src/gadget_range_proof.rs
@@ -8,6 +8,7 @@ use curve25519_dalek::scalar::Scalar;
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use bulletproofs::r1cs::LinearCombination;
+use std::cmp;
 
 use crate::r1cs_utils::{AllocatedQuantity, positive_no_gadget, constrain_lc_with_scalar};
 
@@ -99,6 +100,11 @@ impl PositiveNoGadget {
     Ok(())
 }*/
 
+fn count_log_bits(number: u64) -> usize {
+    let logaritm_int = cmp::min((number as f64).log2() as usize + 1, 64 as usize);
+    return logaritm_int as usize
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,8 +128,8 @@ mod tests {
         let pc_gens = PedersenGens::default();
         let bp_gens = BulletproofGens::new(128, 1);
 
-        // TODO: Use correct bit size of the field
-        let n = 32;
+        let n = count_log_bits(max);
+        println!("bit_size is {}", &n);
 
         let a = v - min;
         let b = max - v;


### PR DESCRIPTION
This function returns a bit size as the `log2(val) +1`. In some edge cases with larger bit sizes the `log2(val)` was found to be not enough.