### PR TITLE
Fix byte ordering

### DIFF
--- a/src/scalar_utils.rs
+++ b/src/scalar_utils.rs
@@ -233,6 +233,8 @@ pub fn get_scalar_from_hex(hex_str: &str) -> Result<Scalar, DecodeHexError> {
     let bytes = decode_hex(hex_str)?;
     let mut result: [u8; 32] = [0; 32];
     result.copy_from_slice(&bytes);
+    // `Scalar` expects byte ordering as little endian
+    result.reverse();
     Ok(Scalar::from_bytes_mod_order(result))
 }
 


### PR DESCRIPTION
Hi! If I'm not mistaken the Scalar struct seems to represent values internally as little endian (cf. https://docs.rs/curve25519-dalek/3.2.1/curve25519_dalek/scalar/struct.Scalar.html#). After decoding the hex string, I think the bytes need to be reversed before creating the scalar.

For example, in this snippet Scalar would represent `1` as `0x01..00` rather than `0x00..01` 
```
let one: u64 = 1;
let s_one = Scalar::from(one);

let bytes_one = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
let s_bytes_one = Scalar::from_bytes_mod_order(bytes_one);

let bytes_one_reverse = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
let s_bytes_one_reverse = Scalar::from_bytes_mod_order(bytes_one_reverse);
    
assert!(s_one != s_bytes_one);
assert!(s_one == s_bytes_one_reverse);
```

Let me know if you have any questions (or disagree) and thanks for publishing your artifacts!!

Thorsten